### PR TITLE
Helixのfile_pickerのキーバインドをspace+fからspace+pに変更

### DIFF
--- a/settings/helix/config.toml
+++ b/settings/helix/config.toml
@@ -20,3 +20,5 @@ D = ["extend_to_line_end", "delete_selection"]
 "S" = "symbol_picker"
 "r" = ":reset-diff-change"
 "q" = ":q!"
+"p" = "file_picker"
+"f" = "no_op"


### PR DESCRIPTION
Helixの設定ファイル(`settings/helix/config.toml`)を編集し、ファイルピッカーの起動キーバインドを変更しました。
- `space + p` でファイルピッカーが起動するように設定
- デフォルトの `space + f` は `no_op` を割り当てて無効化

---
*PR created automatically by Jules for task [14215116222443136390](https://jules.google.com/task/14215116222443136390) started by @nogu3*