### PR TITLE
Helixのspace+eとspace+Eのキーマップの入れ替え

### DIFF
--- a/settings/helix/config.toml
+++ b/settings/helix/config.toml
@@ -22,3 +22,5 @@ D = ["extend_to_line_end", "delete_selection"]
 "q" = ":q!"
 "p" = "file_picker"
 "f" = "no_op"
+"e" = "file_explorer_in_current_buffer_directory"
+"E" = "file_explorer"


### PR DESCRIPTION
Helixの設定で、`space + e`をカレントバッファのディレクトリでのファイルエクスプローラー（`file_explorer_in_current_buffer_directory`）を開くようにし、`space + E`をワークスペースルートでのファイルエクスプローラー（`file_explorer`）を開くように変更しました。これにより、デフォルトの挙動が逆になります。

---
*PR created automatically by Jules for task [9923592804734258667](https://jules.google.com/task/9923592804734258667) started by @nogu3*