### PR TITLE
WezTerm: macOSでの描画エンジンをWebGpuに変更

### DIFF
--- a/settings/wezterm/wezterm.lua
+++ b/settings/wezterm/wezterm.lua
@@ -29,6 +29,7 @@ config.color_scheme = "iceberg-dark"
 -- font size
 if is_mac() then
 	config.font_size = 14
+	config.front_end = "WebGpu"
 else
 	config.font_size = 12
 end

--- a/settings/wezterm/wezterm.lua
+++ b/settings/wezterm/wezterm.lua
@@ -29,9 +29,13 @@ config.color_scheme = "iceberg-dark"
 -- font size
 if is_mac() then
 	config.font_size = 14
-	config.front_end = "WebGpu"
 else
 	config.font_size = 12
+end
+
+-- rendering engine
+if is_mac() then
+	config.front_end = "WebGpu"
 end
 
 -- opacity


### PR DESCRIPTION
WezTermのmacOS環境での描画エンジンをWebGpuに設定しました。
既存のmacOS判定ブロック(`is_mac()`)内に`config.front_end = "WebGpu"`を追加しています。

---
*PR created automatically by Jules for task [3180356347820981427](https://jules.google.com/task/3180356347820981427) started by @nogu3*