### PR TITLE
setup-miseの追加とsetup-floxの削除

### DIFF
--- a/.scripts/setup-flox
+++ b/.scripts/setup-flox
@@ -1,1 +1,0 @@
-ln -s ~/ghq/github.com/nogu3/dotfiles/.flox ~/.flox

--- a/.scripts/setup-mise
+++ b/.scripts/setup-mise
@@ -1,3 +1,4 @@
 #!/bin/sh
-mkdir -p ~/.config/mise
-ln -sf ~/ghq/github.com/nogu3/dotfiles/settings/mise/config.toml ~/.config/mise/config.toml
+mkdir -p ~/.config
+rm -rf ~/.config/mise
+ln -sf ~/ghq/github.com/nogu3/dotfiles/settings/mise ~/.config/mise

--- a/.scripts/setup-mise
+++ b/.scripts/setup-mise
@@ -1,0 +1,3 @@
+#!/bin/sh
+mkdir -p ~/.config/mise
+ln -sf ~/ghq/github.com/nogu3/dotfiles/settings/mise/config.toml ~/.config/mise/config.toml


### PR DESCRIPTION
miseのconfigを適切な位置（`~/.config/mise/config.toml`）に配置するスクリプト `setup-mise` を追加し、不要になった `setup-flox` を削除しました。

---
*PR created automatically by Jules for task [5457200510373687097](https://jules.google.com/task/5457200510373687097) started by @nogu3*