### PR TITLE
refactor: init.shのリファクタリングとmiseセットアップの改善

### DIFF
--- a/.scripts/setup-mise
+++ b/.scripts/setup-mise
@@ -1,4 +1,0 @@
-#!/bin/sh
-mkdir -p ~/.config
-rm -rf ~/.config/mise
-ln -sf ~/ghq/github.com/nogu3/dotfiles/settings/mise ~/.config/mise

--- a/init.sh
+++ b/init.sh
@@ -8,7 +8,6 @@ DRY_RUN=false
 # Targets
 TARGET_MISE=false
 TARGET_DOTTER=false
-TARGET_WINDOWS=false
 
 # Function to display usage
 usage() {
@@ -17,7 +16,6 @@ usage() {
     echo "  -n, --dry-run     Show commands without executing"
     echo "  --mise            Link mise config and run mise install"
     echo "  --dotter          Run dotter deploy"
-    echo "  --windows         Copy Windows specific configs (if on WSL)"
     echo "  -h, --help        Show this help message"
 }
 
@@ -39,11 +37,6 @@ while [[ $# -gt 0 ]]; do
             HAS_TARGET=true
             shift
             ;;
-        --windows)
-            TARGET_WINDOWS=true
-            HAS_TARGET=true
-            shift
-            ;;
         -h|--help)
             usage
             exit 0
@@ -60,10 +53,6 @@ done
 if [[ "$HAS_TARGET" == false ]]; then
     TARGET_MISE=true
     TARGET_DOTTER=true
-
-    if uname -r | grep -qi microsoft; then
-        TARGET_WINDOWS=true
-    fi
 fi
 
 # Execute function
@@ -90,11 +79,6 @@ setup_dotter() {
     execute "dotter deploy"
 }
 
-setup_windows() {
-    echo "copy to wezterm settings files for Windows"
-    execute "cp -r \"$SCRIPT_DIR/settings/wezterm/wezterm.lua\" /mnt/c/Users/noguk/.config/wezterm/wezterm.lua"
-}
-
 # Main execution
 if [[ "$TARGET_MISE" == true ]]; then
     setup_mise
@@ -102,8 +86,4 @@ fi
 
 if [[ "$TARGET_DOTTER" == true ]]; then
     setup_dotter
-fi
-
-if [[ "$TARGET_WINDOWS" == true ]]; then
-    setup_windows
 fi

--- a/init.sh
+++ b/init.sh
@@ -1,38 +1,109 @@
-#!/bin/zsh
-SCRIPT_DIR="${0:a:h}"
+#!/bin/bash
+# Refactored to support mise and dotter setup with modular execution
+set -e
 
-if uname -r | grep -qi microsoft; then
-  OS="WINDOWS"
-else
-  OS="LINUX"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+DRY_RUN=false
+
+# Targets
+TARGET_MISE=false
+TARGET_DOTTER=false
+TARGET_WINDOWS=false
+
+# Function to display usage
+usage() {
+    echo "Usage: $0 [options]"
+    echo "Options:"
+    echo "  -n, --dry-run     Show commands without executing"
+    echo "  --mise            Link mise config and run mise install"
+    echo "  --dotter          Run dotter deploy"
+    echo "  --windows         Copy Windows specific configs (if on WSL)"
+    echo "  -h, --help        Show this help message"
+}
+
+# Parse arguments
+HAS_TARGET=false
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        -n|--dry-run)
+            DRY_RUN=true
+            shift
+            ;;
+        --mise)
+            TARGET_MISE=true
+            HAS_TARGET=true
+            shift
+            ;;
+        --dotter)
+            TARGET_DOTTER=true
+            HAS_TARGET=true
+            shift
+            ;;
+        --windows)
+            TARGET_WINDOWS=true
+            HAS_TARGET=true
+            shift
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            echo "Unknown option: $1"
+            usage
+            exit 1
+            ;;
+    esac
+done
+
+# If no target specified, enable all defaults
+if [[ "$HAS_TARGET" == false ]]; then
+    TARGET_MISE=true
+    TARGET_DOTTER=true
+
+    if uname -r | grep -qi microsoft; then
+        TARGET_WINDOWS=true
+    fi
 fi
 
-# lazygit
-# mkdir -p ~/.config/lazygit
-# rm -f ~/.config/lazygit/config.yml
-# ln -s "$SCRIPT_DIR/settings/lazygit/config.yml" ~/.config/lazygit/config.yml
+# Execute function
+execute() {
+    local cmd="$*"
+    if [[ "$DRY_RUN" == true ]]; then
+        echo "[DRY-RUN] $cmd"
+    else
+        echo "[EXEC] $cmd"
+        eval "$cmd"
+    fi
+}
 
-# neovim
-# mkdir -p ~/.config
-# rm -f ~/.config/nvim
-# ln -s "$SCRIPT_DIR/settings/zenvim" ~/.config/nvim
+setup_mise() {
+    echo "Setting up mise..."
+    execute "mkdir -p ~/.config"
+    execute "rm -rf ~/.config/mise"
+    execute "ln -s \"$SCRIPT_DIR/settings/mise\" ~/.config/mise"
+    execute "mise install"
+}
 
-# zsh
-# common
-# rm -f ~/.zshrc
-# ln -s "$SCRIPT_DIR/settings/zsh/.zshrc" ~/.zshrc
+setup_dotter() {
+    echo "Running dotter deploy..."
+    execute "dotter deploy"
+}
 
-# specific
-# rm -f ~/.zshrc_local
-# ln -s "$SCRIPT_DIR/settings/zsh/.zshrc_local" ~/.zshrc_local
+setup_windows() {
+    echo "copy to wezterm settings files for Windows"
+    execute "cp -r \"$SCRIPT_DIR/settings/wezterm/wezterm.lua\" /mnt/c/Users/noguk/.config/wezterm/wezterm.lua"
+}
 
-# scripts
-# rm -f ~/.scripts
-# ln -s "$SCRIPT_DIR/.scripts" ~/.scripts
+# Main execution
+if [[ "$TARGET_MISE" == true ]]; then
+    setup_mise
+fi
 
-if [[ $OS = "WINDOWS" ]]; then
-  echo "copy to wezterm settings files for Windows"
-  cp -r "$SCRIPT_DIR/settings/wezterm/wezterm.lua" /mnt/c/Users/noguk/.config/wezterm/wezterm.lua
-else
-  # TODO fix ln
+if [[ "$TARGET_DOTTER" == true ]]; then
+    setup_dotter
+fi
+
+if [[ "$TARGET_WINDOWS" == true ]]; then
+    setup_windows
 fi


### PR DESCRIPTION
PR #6を参考に、`init.sh`のリファクタリングを行いました。
加えて、`mise`のセットアップ方法を改善し、不要なスクリプトを削除しました。

主な変更点は以下の通りです。
- zshからbashに変更し、より汎用的なスクリプトにしました。
- `mise`および`dotter`のセットアップ、Windows向けの設定コピー処理をそれぞれ関数化し、引数（`--mise`, `--dotter`, `--windows`）によって個別に実行できるようにしました。
- 引数なしの場合は、環境（WSLかどうかなど）に応じて必要なセットアップが自動的に実行されるようになっています。
- `--dry-run` オプションを追加し、実行されるコマンドを事前に確認できるようにしました。
- `setup_mise`関数にて、`config.toml`単体ではなく、`settings/mise`ディレクトリ全体を`~/.config/mise`にシンボリックリンクするように修正しました。
- これに伴い、不要になった`.scripts/setup-mise`スクリプトを削除しました。
- 使われていなかった古い設定のコメントアウトを削除しました。

---
*PR created automatically by Jules for task [17706754847220281780](https://jules.google.com/task/17706754847220281780) started by @nogu3*