### PR TITLE
WezTermのmacOSのフォントサイズを15に変更

### DIFF
--- a/settings/wezterm/wezterm.lua
+++ b/settings/wezterm/wezterm.lua
@@ -28,7 +28,7 @@ config.color_scheme = "iceberg-dark"
 
 -- font size
 if is_mac() then
-	config.font_size = 14
+	config.font_size = 15
 else
 	config.font_size = 12
 end


### PR DESCRIPTION
WezTermの設定ファイル(`settings/wezterm/wezterm.lua`)を更新し、macOSでのフォントサイズを14から15に変更しました。

---
*PR created automatically by Jules for task [12165349359379703599](https://jules.google.com/task/12165349359379703599) started by @nogu3*