### PR TITLE
mise経由でclaude-codeをインストールするように設定

### DIFF
--- a/settings/mise/config.toml
+++ b/settings/mise/config.toml
@@ -1,4 +1,5 @@
 [tools]
+"npm:@anthropic-ai/claude-code" = "latest"
 helix = "latest"
 fzf = "latest"
 zoxide = "latest"

--- a/settings/mise/config.toml
+++ b/settings/mise/config.toml
@@ -1,5 +1,5 @@
 [tools]
-"npm:@anthropic-ai/claude-code" = "latest"
+claude = "latest"
 helix = "latest"
 fzf = "latest"
 zoxide = "latest"


### PR DESCRIPTION
miseの管理ツールとしてclaude-codeを追加しました。
`npm:@anthropic-ai/claude-code` を `[tools]` セクションに追加しています。

---
*PR created automatically by Jules for task [16233170115570987166](https://jules.google.com/task/16233170115570987166) started by @nogu3*