### PR TITLE
fix: init.shでdotter deployをmise経由で実行するように修正

### DIFF
--- a/init.sh
+++ b/init.sh
@@ -88,7 +88,7 @@ setup_mise() {
 
 setup_dotter() {
     echo "Running dotter deploy..."
-    execute_in_user_shell "dotter deploy"
+    execute_in_user_shell "mise exec -- dotter deploy"
 }
 
 # Main execution


### PR DESCRIPTION
init.sh 内の `dotter deploy` を `mise exec -- dotter deploy` に修正しました。これにより、`mise install` 直後のシェルセッションでも `dotter` が正しくPATHから見つかり、実行されるようになります。

---
*PR created automatically by Jules for task [10083691597864714699](https://jules.google.com/task/10083691597864714699) started by @nogu3*