### PR TITLE
miseにxremapを追加

### DIFF
--- a/settings/mise/config.toml
+++ b/settings/mise/config.toml
@@ -9,3 +9,4 @@ ghq = "latest"
 yazi = "latest"
 "github:googleworkspace/cli" = "latest"
 gcloud = "latest"
+"cargo:xremap" = { version = "latest", os = ["linux"] }


### PR DESCRIPTION
miseの設定にxremapを追加し、Linux環境でのみインストールされるようにしました。

---
*PR created automatically by Jules for task [3235943738761701125](https://jules.google.com/task/3235943738761701125) started by @nogu3*