### PR TITLE
Linux環境でのみmise経由でRustをインストールする設定を追加

### DIFF
--- a/settings/mise/config.toml
+++ b/settings/mise/config.toml
@@ -9,4 +9,5 @@ ghq = "latest"
 yazi = "latest"
 "github:googleworkspace/cli" = "latest"
 gcloud = "latest"
+rust = { version = "latest", os = ["linux"] }
 "cargo:xremap" = { version = "latest", os = ["linux"] }


### PR DESCRIPTION
miseを使って、Linux環境に限定してRustをインストールするように `settings/mise/config.toml` に設定を追加しました。
これは `cargo:xremap` をLinux環境で動作させるための依存関係として必要になります。

---
*PR created automatically by Jules for task [7986140038970990822](https://jules.google.com/task/7986140038970990822) started by @nogu3*