### PR TITLE
xremapのLinux向け設定を追加

### DIFF
--- a/.dotter/global.toml
+++ b/.dotter/global.toml
@@ -16,3 +16,9 @@ depends = []
 
 [settings]
 default_target_type = "automatic"
+
+[linux]
+depends = []
+
+[linux.files]
+"settings/xremap" = { target = "~/.config/xremap", type = "symbolic", recurse = false }

--- a/settings/xremap/config.yml
+++ b/settings/xremap/config.yml
@@ -1,0 +1,49 @@
+keypress_delay_ms: 20
+virtual_modifiers:
+  - CapsLock
+# key to key
+modmap:
+  - name: Global
+    remap:
+      CapsLock:
+        held: Ctrl_L
+        alone: Enter
+      KEY_RIGHTALT:
+        held: CapsLock
+        alone: KEY_RIGHTALT
+      Enter:
+        held: Ctrl_R
+        alone: Henkan
+      Alt_L:
+        held: Alt_L
+        alone: Muhenkan
+      Semicolon: Enter
+
+# key combination to key combination
+keymap:
+  - name: Global
+    remap:
+      Alt-w: Alt-tab
+      CapsLock-s: backspace
+      CapsLock-d: delete
+      CapsLock-i: Up
+      CapsLock-j: Left
+      CapsLock-k: Down
+      CapsLock-l: Right
+      Ctrl_L-Enter: Semicolon
+      Shift-Enter: Shift-Semicolon
+      # for slack
+      Alt-Enter: Ctrl_L-Enter
+      Ctrl_R-w: KEY_1
+      Ctrl_R-e: KEY_2
+      Ctrl_R-r: KEY_3
+      Ctrl_R-s: KEY_4
+      Ctrl_R-d: KEY_5
+      Ctrl_R-f: KEY_6
+      Ctrl_R-x: KEY_7
+      Ctrl_R-c: KEY_8
+      Ctrl_R-v: KEY_9
+      Ctrl_R-a: KEY_0
+      Ctrl_L-CapsLock-j: Home
+      Ctrl_L-CapsLock-l: End
+      Ctrl_L-KEY_DOT: Ctrl_L-c


### PR DESCRIPTION
Linux環境でのみデプロイされるようにdotterのglobal.tomlに `[linux]` パッケージを追加し、settingsForLinuxリポジトリから取得したxremapの設定ファイルへのリンクを設定しました。

---
*PR created automatically by Jules for task [1986974629411614793](https://jules.google.com/task/1986974629411614793) started by @nogu3*